### PR TITLE
feat(ui): highlight today and disable interaction on future dates

### DIFF
--- a/apps/web/src/components/calendar/month-grid.tsx
+++ b/apps/web/src/components/calendar/month-grid.tsx
@@ -27,6 +27,8 @@ export const MonthGrid: React.FC<MonthGridProps> = ({
 }) => {
   const grid = getMonthGrid(year, monthIndex);
 
+  const todayKey = new Date().toISOString().split("T")[0];
+
   return (
     <div className="flex flex-col gap-3 w-full max-w-full">
       <div className="flex items-center justify-between mb-1">
@@ -36,12 +38,11 @@ export const MonthGrid: React.FC<MonthGridProps> = ({
       </div>
 
       <div className="flex gap-2 w-full">
-        {/* Weekday labels - only show for first month of quarter */}
         {showWeekdays && (
           <div className="flex flex-col gap-[8px] md:gap-[10px] lg:gap-[12px] pt-1 shrink-0">
             {WEEKDAYS.map((day) => (
               <div key={day} className="h-7 md:h-8 lg:h-10 flex items-center">
-                <span className="text-[8px] md:text-[9px] font-bold text-gray-600 tracking-tighter">
+                <span className="text-[8px] md:text-[9px] font-bold text-gray-600">
                   {day}
                 </span>
               </div>
@@ -49,7 +50,6 @@ export const MonthGrid: React.FC<MonthGridProps> = ({
           </div>
         )}
 
-        {/* The Grid */}
         <div className="flex flex-col gap-[6px] md:gap-[8px] lg:gap-[10px] flex-1 min-w-0">
           {grid.map((row, rowIndex) => (
             <div
@@ -59,6 +59,8 @@ export const MonthGrid: React.FC<MonthGridProps> = ({
               {row.map((day, colIndex) => {
                 const entry = day ? dayEntries[day.dateKey] : undefined;
                 const reviews = entry ? reviewsByEntry[entry.id] || [] : [];
+                const isToday = day?.dateKey === todayKey;
+
                 return (
                   <DayTile
                     key={`${rowIndex}-${colIndex}`}
@@ -67,6 +69,7 @@ export const MonthGrid: React.FC<MonthGridProps> = ({
                     reviews={reviews}
                     onClick={onTileClick}
                     showReviews={showReviews}
+                    isToday={isToday}
                   />
                 );
               })}


### PR DESCRIPTION
This PR improves the calendar month grid UX by making date state more explicit and predictable.

What changed
- Visually highlights the current day to improve orientation.
- Disables hover, popover, and click interactions for future dates.
- Adds a clear locked state for future days to prevent accidental actions.

Why
- Users should immediately identify “today” without scanning.
- Future dates are not actionable, so allowing interaction created confusion.
- Keeps behavior consistent with existing entry constraints.

Screenshots
- Before: calendar without today emphasis and future dates interactive

<img width="1862" height="924" alt="image" src="https://github.com/user-attachments/assets/3bcc90a4-5124-4cda-a008-eaf568bd4bdf" />

- After: today highlighted and future dates visibly disabled

<img width="1848" height="892" alt="image" src="https://github.com/user-attachments/assets/7d739a04-0ba5-487f-8afd-582c706c9296" />

