### PR TITLE
Fix: Calendar overflow issue causing August dates to be cut off

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -204,7 +204,7 @@ export default function Home() {
         {/* Main Layout Grid */}
         <div className="flex flex-col lg:flex-row gap-8 lg:gap-12">
           {/* Year View */}
-          <div className="flex-1 space-y-10 md:space-y-12 lg:space-y-16 overflow-hidden">
+          <div className="flex-1 space-y-10 md:space-y-12 lg:space-y-16 min-w-0">
             {QUADRIMESTERS.map((quad, qIndex) => (
               <section
                 key={quad.name}
@@ -218,9 +218,9 @@ export default function Home() {
                   <div className="h-px bg-linear-to-r from-[#22D3EE]/30 to-transparent w-full" />
                 </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-y-6 md:gap-y-8 gap-x-3 md:gap-x-4 lg:gap-x-6 justify-items-center lg:justify-items-start">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-y-6 md:gap-y-8 gap-x-3 md:gap-x-4 lg:gap-x-6 justify-items-center lg:justify-items-start min-w-0">
                   {quad.months.map((mIdx, idx) => (
-                    <div key={mIdx} className="w-full max-w-sm md:max-w-none">
+                    <div key={mIdx} className="w-full max-w-sm md:max-w-none min-w-0">
                       <MonthGrid
                         year={year}
                         monthIndex={mIdx}

--- a/apps/web/src/components/calendar/month-grid.tsx
+++ b/apps/web/src/components/calendar/month-grid.tsx
@@ -30,14 +30,14 @@ export const MonthGrid: React.FC<MonthGridProps> = ({
   const todayKey = new Date().toISOString().split("T")[0];
 
   return (
-    <div className="flex flex-col gap-3 w-full max-w-full">
+    <div className="flex flex-col gap-3 w-full max-w-full min-w-0">
       <div className="flex items-center justify-between mb-1">
         <h4 className="text-[10px] md:text-[11px] font-bold text-gray-400 tracking-[0.15em] md:tracking-[0.2em] uppercase">
           {MONTHS[monthIndex]} {year}
         </h4>
       </div>
 
-      <div className="flex gap-2 w-full">
+      <div className="flex gap-2 w-full min-w-0">
         {showWeekdays && (
           <div className="flex flex-col gap-[8px] md:gap-[10px] lg:gap-[12px] pt-1 shrink-0">
             {WEEKDAYS.map((day) => (
@@ -50,7 +50,7 @@ export const MonthGrid: React.FC<MonthGridProps> = ({
           </div>
         )}
 
-        <div className="flex flex-col gap-[6px] md:gap-[8px] lg:gap-[10px] flex-1 min-w-0">
+        <div className="flex flex-col gap-[6px] md:gap-[8px] lg:gap-[10px] flex-1 min-w-0 overflow-visible">
           {grid.map((row, rowIndex) => (
             <div
               key={rowIndex}


### PR DESCRIPTION
## Issue
The August month calendar dates were being cut off in the UI due to `overflow-hidden` on the parent container and missing flex constraints, preventing proper layout rendering in the 4-column grid.

## Solution
Fixed overflow and flex constraints by:
- Replaced `overflow-hidden` with `min-w-0` on the year view container to allow proper flex shrinking
- Added `min-w-0` to grid and month wrapper containers for correct flex behavior
- Added `overflow-visible` to the calendar grid container to prevent date clipping

## Changes Made
- **`apps/web/src/app/page.tsx`**: Updated parent container and grid wrapper classes
- **`apps/web/src/components/calendar/month-grid.tsx`**: Added flex constraints and overflow handling

## Screenshots
### Before
<img width="1616" height="615" alt="image" src="https://github.com/user-attachments/assets/38fce609-977e-4bfd-987e-5d6178bb0d4c" />

### After
<img width="1591" height="616" alt="image" src="https://github.com/user-attachments/assets/c51fa46f-6a11-45e5-aff2-ee1d531676a6" />