### PR TITLE
fix: unable to update reviews & category

### DIFF
--- a/apps/web/src/lib/api/calendar.ts
+++ b/apps/web/src/lib/api/calendar.ts
@@ -276,6 +276,7 @@ export function useCreateReview() {
     mutationFn: createReview,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["day-entry"] });
+      queryClient.invalidateQueries({ queryKey: ["year-entries"] });
     },
   });
 }
@@ -286,6 +287,7 @@ export function useUpdateReview() {
     mutationFn: updateReview,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["day-entry"] });
+      queryClient.invalidateQueries({ queryKey: ["year-entries"] });
     },
   });
 }
@@ -296,6 +298,7 @@ export function useDeleteReview() {
     mutationFn: deleteReview,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["day-entry"] });
+      queryClient.invalidateQueries({ queryKey: ["year-entries"] });
     },
   });
 }


### PR DESCRIPTION
### Description
Reviews and category were not updating after creation, causing a “failed to save day entry, please try again” error.

### Changes made

- Fixed issue preventing reviews and category from updating after creation

- Resolved false save failure message for day entries

- Added loader state while saving and updating for better UX

- Invalidating query to show the updated entry for better UX