### PR TITLE
feat: Add keyboard navigation handlers to day modal (Enter, Arrow key…

### DIFF
--- a/apps/web/src/components/calendar/day-modal.tsx
+++ b/apps/web/src/components/calendar/day-modal.tsx
@@ -146,6 +146,70 @@ export const DayModal: React.FC<DayModalProps> = ({
     });
   };
 
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (!day) return;
+
+    if (step === 1 && ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Enter"].includes(e.key)) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    if (step === 2 && (e.target as HTMLElement)?.tagName === 'TEXTAREA') {
+      if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+        e.preventDefault();
+        handleSave();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        handleBack();
+      }
+      return;
+    }
+
+    if (step === 1) {
+      if (e.key === "Enter" && !isFuture) {
+        handleNext();
+        return;
+      }
+
+      if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(e.key)) {
+        const currentIndex = legends.indexOf(selectedLegend);
+
+        if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+          const prevIndex = (currentIndex - 1 + legends.length) % legends.length;
+          setSelectedLegend(legends[prevIndex]);
+        }
+        if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+          const nextIndex = (currentIndex + 1) % legends.length;
+          setSelectedLegend(legends[nextIndex]);
+        }
+        return;
+      }
+
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+    }
+
+    if (step === 2) {
+      if ((e.ctrlKey || e.metaKey) && e.key === "Enter" && !isFuture) {
+        e.preventDefault();
+        handleSave();
+        return;
+      }
+
+      if (e.key === "Escape") {
+        handleBack();
+        return;
+      }
+    }
+  };
+
   const handleSkipReviews = () => {
     onSave({
       date: day.dateKey,
@@ -153,6 +217,16 @@ export const DayModal: React.FC<DayModalProps> = ({
       reviews: [],
     });
   };
+
+  useEffect(() => {
+    if (!day) return;
+
+    document.addEventListener('keydown', handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [step, day, handleNext, handleSave, handleBack, onClose, selectedLegend, legends, isFuture, handleKeyDown]);
 
   return (
     <Dialog open={!!day} onOpenChange={onClose}>


### PR DESCRIPTION
## Description
Added comprehensive keyboard navigation support to the DayModal component, making the application fully accessible to keyboard-only users and improving overall user experience.

### Changes Made
- ✅ **Enter Key** - Proceed from Step 1 (mood selection) to Step 2 (reviews)
- ✅ **Arrow Left/Right Keys** - Navigate between different moods in Step 1
- ✅ **Arrow Up/Down Keys** - Navigate between different moods in Step 1 (alternative to left/right)
- ✅ **Ctrl+Enter (or Cmd+Enter on Mac)** - Save entry from Step 2
- ✅ **Escape Key** - Close modal from Step 1 or go back to Step 1 from Step 2
- ✅ **Smart Event Handling** - Arrow keys don't trigger navigation while typing in textareas
