### PR TITLE
feat: replace hardcoded year with dynamic current year

### DIFF
--- a/apps/server/src/api/controllers/days.controller.ts
+++ b/apps/server/src/api/controllers/days.controller.ts
@@ -14,6 +14,8 @@ export const getYearEntries = async (
   try {
     const userId = req.user?.id;
 
+    const year = req.query.year ? Number(req.query.year) : new Date().getFullYear();
+
     if (!userId) {
       res.status(401).json({
         message: "Authentication required",
@@ -27,8 +29,8 @@ export const getYearEntries = async (
       .where(
         and(
           eq(dayEntry.userId, userId),
-          gte(dayEntry.date, "2026-01-01"),
-          lte(dayEntry.date, "2026-12-31")
+          gte(dayEntry.date, `${year}-01-01`),
+          lte(dayEntry.date, `${year}-12-31`)
         )
       )
       .orderBy(dayEntry.date);

--- a/apps/server/src/api/routes/days.routes.ts
+++ b/apps/server/src/api/routes/days.routes.ts
@@ -43,7 +43,7 @@ const validateUpdateDayEntry = (req: any, res: any, next: any) => {
 router.use(authenticate);
 
 // Routes
-router.get("/2026", getYearEntries);
+router.get("/", getYearEntries);
 router.get("/:date", getDayEntry);
 router.post("/", validateCreateDayEntry, createOrUpdateDayEntry);
 router.put("/:date", validateUpdateDayEntry, updateDayEntry);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -19,14 +19,14 @@ import { authClient } from "@/lib/auth-client";
 import SignInDialog from "@/components/auth/sign-in-dialog";
 
 export default function Home() {
-  const [year] = useState(2026);
+  const [year] = useState(new Date().getFullYear());
   const [selectedDay, setSelectedDay] = useState<DayInfo | null>(null);
   const [signInOpen, setSignInOpen] = useState(false);
 
   const { data: session, isPending: isSessionLoading } =
     authClient.useSession();
 
-  const { data: yearData, isLoading: isLoadingYear } = useYearEntries();
+  const { data: yearData, isLoading: isLoadingYear } = useYearEntries(year);
   const { data: customCategoriesData } = useCustomCategories();
   const { data: dayData } = useDayEntry(selectedDay?.dateKey || null);
 

--- a/apps/web/src/lib/api/calendar.ts
+++ b/apps/web/src/lib/api/calendar.ts
@@ -30,9 +30,8 @@ type ProfileSettingsResponse = {
 };
 
 // API Functions
-
-const getYearEntries = async (): Promise<YearEntriesResponse> => {
-  const response = await fetch(`${API_URL}/api/days/2026`, {
+const getYearEntries = async (year: number): Promise<YearEntriesResponse> => {
+  const response = await fetch(`${API_URL}/api/days?year=${year}`, {
     credentials: "include",
   });
   if (!response.ok) {
@@ -234,11 +233,10 @@ const getPublicProfile = async (userIdOrSlug: string): Promise<any> => {
 };
 
 // React Query Hooks
-
-export function useYearEntries() {
-  return useQuery({
-    queryKey: ["year-entries"],
-    queryFn: getYearEntries,
+export function useYearEntries(year: number) {
+  return useQuery({ 
+    queryKey: ["year-entries", year], 
+    queryFn: () => getYearEntries(year),
   });
 }
 


### PR DESCRIPTION
### Summary
This PR fixes the issue where the application was hardcoded to the year **2026**. The app now dynamically uses the current year (e.g., 2025 or 2026) for both the UI and API requests.

### Changes
- **Backend:** Updated `days.controller.ts` and `days.routes.ts` to accept a `?year=` query parameter (defaults to current year if missing).
- **Frontend API:** Updated `getYearEntries` and `useYearEntries` hook in `calendar.ts` to accept a `year` argument.
- **Frontend UI:** `page.tsx` now initializes state with `new Date().getFullYear()` instead of `2026`.

### How to Test
1. Run `bun run dev`
2. Open `http://localhost:3003`
3. Verify the page loads successfully (displaying the current year) without 404 errors.