### PR TITLE
feat: make server port configurable via env variable

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,6 +8,7 @@ import reviewsRoutes from "./api/routes/reviews.routes";
 import categoriesRoutes from "./api/routes/categories.routes";
 import profileRoutes from "./api/routes/profile.routes";
 
+const port = process.env.PORT || 3009;
 const app = express();
 
 app.use(
@@ -34,8 +35,9 @@ app.get("/api/health", (_req, res) => {
     message: "OK! API is running",
   });
 });
-app.listen(3009, () => {
-  console.log("Server is running on http://localhost:3009");
+
+app.listen(port, () => {
+  console.log(`Server is running on http://localhost:${port}`);
   console.log("Environment variables:", {
     DATABASE_URL: env.DATABASE_URL
       ? env.DATABASE_URL.substring(0, 3) + "..."


### PR DESCRIPTION
### Summary
Updated the server to allow configuring the port via the `PORT` environment variable. It defaults to `3009` if no variable is set.

### Changes
- Modified `apps/server/src/index.ts` to use `process.env.PORT || 3009`.
- Updated console logs to show the actual running port.

### How to Test
1. Run `bun run dev:server` -> verifies it runs on 3009 by default.
2. Add `PORT=4000` to `.env` and restart -> verifies it switches to 4000.